### PR TITLE
Build slimmer Docker images.

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,3 @@
+LICENSE
+*.md
+*.png

--- a/Dockerfile.alpine
+++ b/Dockerfile.alpine
@@ -1,13 +1,25 @@
-FROM mhart/alpine-node:4
-RUN apk update && apk add --update procps git curl && rm -rf /var/cache/apk/*
-RUN mkdir -p /usr/src/app
+FROM alpine:edge
+
+RUN apk --no-cache add \
+    tini \
+    nodejs \
+    procps \
+    curl
+
+COPY . /usr/src/app
 WORKDIR /usr/src/app
 
-COPY package.json /usr/src/app/
-COPY . /usr/src/app
-RUN npm install -g
+RUN apk --no-cache add --virtual deps git \
+  && npm install -g \
+  && apk del deps \
+  # Clean up obsolete files:
+  && rm -rf \
+    /tmp/* \
+    /root/.npm
 
-COPY ./run.sh /run.sh
-RUN chmod +x /run.sh
+RUN ln -s /usr/src/app/run.sh /usr/local/bin/run-sematext-agent
+
 EXPOSE 9000
-CMD /run.sh
+
+ENTRYPOINT ["tini", "--"]
+CMD ["run-sematext-agent"]

--- a/run.sh
+++ b/run.sh
@@ -1,30 +1,32 @@
-set -e 
+#!/bin/sh
+
+set -e
 export spmagent_spmSenderBulkInsertUrl=${SPM_URL:-https://spm-receiver.sematext.com:443/receiver/v1/_bulk}
 export DOCKER_PORT=${DOCKER_PORT:-2375}
 export LOGSENE_TMP_DIR=/logsene-log-buffer
 mkdir -p $LOGSENE_TMP_DIR
 
-if [ -z "${DOCKER_HOST}" ]; then 
-	if [ -r /var/run/docker.sock ]; then 
-        export DOCKER_HOST=unix:///var/run/docker.sock
-	else
-        export DOCKER_HOST=tcp://$(netstat -nr | grep '^0\.0\.0\.0' | awk '{print $2}'):$DOCKER_PORT
-        echo "/var/run/docker.sock is not available set DOCKER_HOST=$DOCKER_HOST"
-	fi
+if [ -z "${DOCKER_HOST}" ]; then
+  if [ -r /var/run/docker.sock ]; then
+    export DOCKER_HOST=unix:///var/run/docker.sock
+  else
+    export DOCKER_HOST=tcp://$(netstat -nr | grep '^0\.0\.0\.0' | awk '{print $2}'):$DOCKER_PORT
+    echo "/var/run/docker.sock is not available set DOCKER_HOST=$DOCKER_HOST"
+  fi
 fi
 
 export HOSTNAME=$(docker-info Name)
 echo "Docker Hostname: ${HOSTNAME}"
 
-if [ -n "${DOCKERCLOUD_NODE_HOSTNAME}" ]; then 
-	export HOSTNAME=$DOCKERCLOUD_NODE_HOSTNAME
-	echo "Docker Cloud Node Hostname: ${HOSTNAME}"
+if [ -n "${DOCKERCLOUD_NODE_HOSTNAME}" ]; then
+  export HOSTNAME=$DOCKERCLOUD_NODE_HOSTNAME
+  echo "Docker Cloud Node Hostname: ${HOSTNAME}"
 fi
 
-if [ -n "${HOSTNAME_LOOKUP_URL}" ]; then 
-	echo Hostname lookup: ${HOSTNAME_LOOKUP_URL}
-	export HOSTNAME=$(curl -s $HOSTNAME_LOOKUP_URL)
-	echo "Hostname lookup from ${HOSTNAME_LOOKUP_URL}: ${HOSTNAME}"
+if [ -n "${HOSTNAME_LOOKUP_URL}" ]; then
+  echo Hostname lookup: ${HOSTNAME_LOOKUP_URL}
+  export HOSTNAME=$(curl -s $HOSTNAME_LOOKUP_URL)
+  echo "Hostname lookup from ${HOSTNAME_LOOKUP_URL}: ${HOSTNAME}"
 fi
 
-sematext-agent-docker ${SPM_TOKEN} 
+exec sematext-agent-docker ${SPM_TOKEN}


### PR DESCRIPTION
This is a proposed change to build slimmer Docker images while retaining all original functionality.

The size savings are as following:
- Debian image: 379.7 MB => 287.2 MB
- Alpine image: 146 MB => 88.68 MB

Additionally, the new Dockerfiles also include the following changes:
- Add tini as docker entrypoint - see https://github.com/krallin/tini/issues/8
- Use exec to start the the run script and sematext-agent-docker to avoid unnecessary shell processes.

Thanks for your consideration.
