### PR TITLE
Don't output received logs to stdout.

### DIFF
--- a/lib/tcpLogReceiver.js
+++ b/lib/tcpLogReceiver.js
@@ -34,7 +34,6 @@ function TcpJsonReceiver (port) {
                 result[key.toLowerCase()] = val
               }
             })
-            console.log(ldData)
             self.emit('data', ldData)
           }
         })


### PR DESCRIPTION
For my setup(forwarding journalctl -> sematext agent), this is causing an infinite loop of duplicate logs.