### PR TITLE
Add Base64 encoding support for Logagent patterns file environment variable 

### DIFF
--- a/help.1
+++ b/help.1
@@ -106,6 +106,8 @@ SKIP\_BY\_IMAGE		Regular expression to black list image names for logging
 
 PATTERNS\_URL		Load pattern.yml via HTTP e.g. \fB\fC\-e PATTERNS\_URL=https://raw.githubusercontent.com/sematext/logagent\-js/master/patterns.yml\fR	
 
+LOGAGENT\_PATTERNS\_BASE64		Set to "true" if the LOGAGENT\_PATTERNS patterns file you are passing in via env. variable is base64 encoded e.g \fB\fC\-e LOGAGENT\_PATTERNS="$(cat ./patterns.yml | base64)"\fR. Useful if your params file is not getting set properly due to shell interpretation or otherwise.
+
 LOGAGENT\_PATTERNS		Pass patterns.yml via env. variable e.g. \fB\fC\-e LOGAGENT\_PATTERNS="$(cat ./patters.yml)"\fR	
 
 PATTERN\_MATCHING\_ENABLED		Activate 

--- a/help.md
+++ b/help.md
@@ -65,7 +65,7 @@ Watch metrics, use anomaly detection for alerts, create e-mail reports and much 
 | SKIP_BY_NAME | Regular expression to black list container names |
 | SKIP_BY_IMAGE | Regular expression to black list image names for logging | 
 | PATTERNS_URL | Load pattern.yml via HTTP e.g. ```-e PATTERNS_URL=https://raw.githubusercontent.com/sematext/logagent-js/master/patterns.yml``` |
-| LOGAGENT_PATTERNS_BASE64 | Set to "true" if the LOGAGENT_PATTERNS patterns file you are passing in via env. variable is base64 encoded e.g ```-e LOGAGENT_PATTERNS="$(cat ./patterns.yml | base64)"```. Useful if your params file is not getting set properly due to shell interpretation or otherwise. |
+| LOGAGENT_PATTERNS_BASE64 | Set to "true" if the LOGAGENT_PATTERNS patterns file you are passing in via env. variable is base64 encoded e.g ```-e LOGAGENT_PATTERNS="$(cat ./patterns.yml \| base64)"```. Useful if your params file is not getting set properly due to shell interpretation or otherwise. |
 | LOGAGENT_PATTERNS | Pass patterns.yml via env. variable e.g. ```-e LOGAGENT_PATTERNS="$(cat ./patters.yml)"``` |
 | PATTERN_MATCHING_ENABLED | Activate [logagent-js parser](https://sematext.github.io/logagent-js/parser/), default value is ```true```. To disable the log parser set the value to ```false```. This could increase the throughput of log processing for nodes with a very high log volume.|
 | -v /yourpatterns/patterns.yml:/etc/logagent/patterns.yml | to provide custom patterns for log parsing, see [logagent-js](https://github.com/sematext/logagent-js)|

--- a/help.md
+++ b/help.md
@@ -65,6 +65,7 @@ Watch metrics, use anomaly detection for alerts, create e-mail reports and much 
 | SKIP_BY_NAME | Regular expression to black list container names |
 | SKIP_BY_IMAGE | Regular expression to black list image names for logging | 
 | PATTERNS_URL | Load pattern.yml via HTTP e.g. ```-e PATTERNS_URL=https://raw.githubusercontent.com/sematext/logagent-js/master/patterns.yml``` |
+| LOGAGENT_PATTERNS_BASE64 | Set to "true" if the LOGAGENT_PATTERNS patterns file you are passing in via env. variable is base64 encoded e.g ```-e LOGAGENT_PATTERNS="$(cat ./patterns.yml | base64)"```. Useful if your params file is not getting set properly due to shell interpretation or otherwise. |
 | LOGAGENT_PATTERNS | Pass patterns.yml via env. variable e.g. ```-e LOGAGENT_PATTERNS="$(cat ./patters.yml)"``` |
 | PATTERN_MATCHING_ENABLED | Activate [logagent-js parser](https://sematext.github.io/logagent-js/parser/), default value is ```true```. To disable the log parser set the value to ```false```. This could increase the throughput of log processing for nodes with a very high log volume.|
 | -v /yourpatterns/patterns.yml:/etc/logagent/patterns.yml | to provide custom patterns for log parsing, see [logagent-js](https://github.com/sematext/logagent-js)|

--- a/run.sh
+++ b/run.sh
@@ -32,9 +32,16 @@ if [ -n "${PATTERNS_URL}" ]; then
 fi
 
 if [ -n "${LOGAGENT_PATTERNS}" ]; then
-  mkdir -p /etc/logagent
-  echo "writing LOGAGENT_PATTERNS to /etc/logagent/patterns.yml"
-  echo "$LOGAGENT_PATTERNS" > /etc/logagent/patterns.yml
+  if [ "${LOGAGENT_PATTERNS_BASE64}" == "true" ]; then
+    # If the logagent patterns file is an environment variable, and base64 encoded
+    mkdir -p /etc/logagent
+    echo "writing LOGAGENT_PATTERNS to /etc/logagent/patterns.yml"
+    echo "$LOGAGENT_PATTERNS" | base64 -d > /etc/logagent/patterns.yml
+  else
+    mkdir -p /etc/logagent
+    echo "writing LOGAGENT_PATTERNS to /etc/logagent/patterns.yml"
+    echo "$LOGAGENT_PATTERNS" > /etc/logagent/patterns.yml
+  fi
 fi
 
 export GEOIP_ENABLED=${GEOIP_ENABLED:-"false"}


### PR DESCRIPTION
We had some issues with passing the Logagent patterns file via environment variable into the Sematext container. The environment variable inside the container would only include the first line of the patterns file. 

We were able to get the patterns file working with the default `-e LOGAGENT_PATTERNS="$(cat patterns.yml)"`, but we do not use this for our sematext agents. We use .env files with populated environment variables that are then passed in docker-compose with the `env_file:` directive. Because of this, we ran into issues where populating the .env file would result in issues where only the first line of the patterns file would make it to the sematext container. 

An example of the issue:

```
cat test.sh
#! /bin/sh
cat << EOF > x.env
LOGAGENT_PATTERNS=$(cat ./patterns.yml)
EOF
```

```
cat x.env | head -10
LOGAGENT_PATTERNS=#
# PARSER DEFINITIONS FILE IN YML FORMAT
#
# Please use 'ts' as feild name for dates and time

# set originalLine to false when auothash fields
# the original line might include sensitive data!
originalLine: false
# default seperator for multiline logs,
# which don't have a blockStart property
```
In this case the logagent pattern would only be set to `#`

We fixed this by base64 wrapping the whole patterns file, and decoding it inside the container. We have done this before for some of our dockerized Tozny services internally. We have tested this on our own branch, and are currently running our custom build on a few servers with no issues. The patterns file is properly decoded inside the container without issue. 

With base64 wrapping:
```
cat test.sh
#! /bin/sh
cat << EOF > x.env
LOGAGENT_PATTERNS=$(cat ./patterns.yml | openssl base64 -A)
EOF
```

```
LOGAGENT_PATTERNS=IwojIFBBUlNFUiBERUZJTklUSU9OUyBGSUxFIElOIFlNTCBGT1JNQVQKIwojIFBsZWFzZSB1c2UgJ3RzJyBhcyBmZWlsZCBuYW1lIGZvciBkYXRlcyBhbmQgdGltZQoKIyBzZXQgb3JpZ2luYWxMaW5lIHRvIGZhbHNlIHdoZW4gYXVvdGhhc2ggZmllbGRzCiMgdGhlIG9yaWdpbmFsIGxpbmUgbWlnaHQgaW5jbHVkZSBzZW5zaXRpdmUgZGF0YSEKb3JpZ2luYWxMaW5lOiBmYWxzZQojIGRlZmF1bHQgc2VwZXJhdG9 (continued)
```
This way the base64 contents are a single-line string that gets passed to the container without breaking on newlines, returns, bash interpolation, etc. 

This code changes does not change the original functionality of the LOGAGENT_PARAMS environment variable, and is backwards compatible. If the LOGAGENT_PARAMS_BASE64 variable is set to "true", then the container will decode the environment variable with base64. Otherwise, it treats the environment variable as plaintext as before. This way users can continue to use command line LOGAGENT_PARAMS like `-e LOGAGENT_PATTERNS="$(cat patterns.yml)"` or can use base64 encoded version with .env files. 

